### PR TITLE
fix for pool.ts cache keys

### DIFF
--- a/src/lib/pool.ts
+++ b/src/lib/pool.ts
@@ -543,7 +543,7 @@ export class Pool extends Base {
   }
 
   async getPoolTypeArguments(poolId: string): Promise<Pool.Types> {
-    return this.getCacheOrSet('pool-type-' + poolId, async () => {
+    return this.getCacheOrSet('pool-types-' + poolId, async () => {
       const result = await this.getPool(poolId);
       return result.types;
     });


### PR DESCRIPTION
pool.ts: using separate cache key for pool types (type arguments) and pool object type (Move object type)